### PR TITLE
bug1219487 - avoid invalid scopes containing \n

### DIFF
--- a/tests/taskcluster/lib/decorate_task.js
+++ b/tests/taskcluster/lib/decorate_task.js
@@ -13,10 +13,10 @@ var GAIA_DIR = path.resolve(__dirname, '..', '..', '..');
 
 // Default image name / version this can be overriden at the task level...
 var IMAGE =
-  fs.readFileSync(GAIA_DIR + '/build/docker/gaia-taskenv/DOCKER_TAG', 'utf8');
+  fs.readFileSync(GAIA_DIR + '/build/docker/gaia-taskenv/DOCKER_TAG', 'utf8').trim();
 
 var VERSION =
-  fs.readFileSync(GAIA_DIR + '/build/docker/gaia-taskenv/VERSION', 'utf8');
+  fs.readFileSync(GAIA_DIR + '/build/docker/gaia-taskenv/VERSION', 'utf8').trim();
 
 // Default provisioner and worker types
 var COPIED_ENVS = [
@@ -82,7 +82,7 @@ function decorateTask(task, options) {
 
   // Default docker image...
   var payload = output.task.payload;
-  payload.image = payload.image || (IMAGE.trim()) + ':' + (VERSION.trim());
+  payload.image = payload.image || IMAGE + ':' + VERSION;
   payload.maxRunTime = payload.maxRunTime || 30 * 60; // 30 minutes in seconds
 
   // Copy over the important environment variables...


### PR DESCRIPTION
Avoid invalid scopes containing `\n`

See: https://bugzilla.mozilla.org/show_bug.cgi?id=1219487

Needs to be carried across all branches that has TC automation, or automation will fail when I roll out new restrictions on allowed input for `task.scopes` soon.
